### PR TITLE
fix the bug:'dict' object has no attribute 'to' 

### DIFF
--- a/janus_pro_caption.py
+++ b/janus_pro_caption.py
@@ -164,7 +164,7 @@ class JanusProDescribeImage:
 
         if not keep_model_loaded:
             print("Offloading model...")
-            model.to(mm.unet_offload_device())
+            model["model"].to(mm.unet_offload_device())
             mm.soft_empty_cache()
 
         return (answer,)
@@ -230,7 +230,7 @@ class JanusProCaptionImageUnderDirectory:
                                       model, question, seed, temperature, top_p, max_new_tokens)
         if not keep_model_loaded:
             print("Offloading model...")
-            model.to(mm.unet_offload_device())
+            model["model"].to(mm.unet_offload_device())
             mm.soft_empty_cache()
 
         return result


### PR DESCRIPTION
fix the bug:
when "Janus Pro Describle Image" node's "keep_model_loaded" set false, throw 'dict' object has no attribute 'to' error to the console
![20250306-121721](https://github.com/user-attachments/assets/b7ddc73a-ee64-44ce-83d0-75b36af120df)
